### PR TITLE
fpc1020: change button press to send to KEY_LEFTMETA instead of KEY_HOME

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,11 +2,6 @@ Source: linux-android-oneplus-msm8998
 Section: kernel
 Priority: optional
 Maintainer: Droidian porters <info@droidian.org>
-Uploaders: Eugenio Paolantonio (g7) <eugenio@droidian.org>,
-           r3vn <giuseppe@droidian.org>,
-           Erfan Abdi <erfan@droidian.org>,
-           Erik Inkinen <erik@droidian.org>,
-           Bardia Moshiri <fakeshell@bardia.tech>,
 XS-Droidian-Host-Arch: arm64
 XS-Droidian-Build-On: amd64
 Build-Depends: build-essential,
@@ -27,10 +22,11 @@ Build-Depends: build-essential,
                mkbootimg (>= 10.0.0),
                mkdtboimg,
                avbtool,
+               lz4,
                linux-initramfs-halium-generic:arm64, binutils-aarch64-linux-gnu, gcc-4.9-aarch64-linux-android, g++-4.9-aarch64-linux-android, libgcc-4.9-dev-aarch64-linux-android-cross
 Standards-Version: 4.5.0.3
-Vcs-Browser: https://github.com/droidian/linux-android-oneplus-msm8998
-Vcs-Git: https://github.com/droidian/linux-android-oneplus-msm8998.git
+Vcs-Browser: https://github.com/droidian-devices/linux-android-oneplus-msm8998
+Vcs-Git: https://github.com/droidian-devices/linux-android-oneplus-msm8998.git
 
 Package: linux-image-4.4.153-oneplus-msm8998
 Architecture: arm64

--- a/drivers/input/fingerprint/fpc/fpc1020_tee.c
+++ b/drivers/input/fingerprint/fpc/fpc1020_tee.c
@@ -332,13 +332,13 @@ static ssize_t report_home_set(struct device *dev,
 	if (!strncmp(buf, "down", strlen("down")))
 	{
             input_report_key(fpc1020->input_dev,
-                            KEY_HOME, 1);
+                            KEY_LEFTMETA, 1);
             input_sync(fpc1020->input_dev);
 	}
 	else if (!strncmp(buf, "up", strlen("up")))
 	{
             input_report_key(fpc1020->input_dev,
-                            KEY_HOME, 0);
+                            KEY_LEFTMETA, 0);
             input_sync(fpc1020->input_dev);
 	}
     else if (!strncmp(buf, "timeout", strlen("timeout")))
@@ -458,7 +458,7 @@ int fpc1020_input_init(struct fpc1020_data *fpc1020)
 
 		set_bit(KEY_POWER, fpc1020->input_dev->keybit);
 		set_bit(KEY_F2, fpc1020->input_dev->keybit);
-		set_bit(KEY_HOME, fpc1020->input_dev->keybit);
+		set_bit(KEY_LEFTMETA, fpc1020->input_dev->keybit);
 		set_bit(KEY_FINGERPRINT, fpc1020->input_dev->keybit);
 
 		/*


### PR DESCRIPTION
Having the button send KEY_HOME would cause wonky behaviour in Phosh, so changed it to send KEY_LEFTMETA instead, which is what the OnePlus 3/3T does too.